### PR TITLE
Bump dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,11 +11,11 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "~0.1.3",
-    "purescript-react-dom": "^0.2.0",
-    "purescript-options": "~0.6.0"
+    "purescript-prelude": "^2.1.0",
+    "purescript-react-dom": "^2.0.0",
+    "purescript-options": "^2.0.0"
   },
   "devDependencies": {
-    "purescript-react-wrapper-gen": "../purescript-react-wrapper-gen"
+    "purescript-react-wrapper-gen": "bartadv/purescript-react-wrapper-gen#8d0831c5ec7eb89ffa2eab9115973a42edbb13ff"
   }
 }


### PR DESCRIPTION
Ideally, the wrapper dev dependency would point to the mainline, but at this point this PR is just shameless reminder to figure out how to run it against latest material-ui ;)